### PR TITLE
debian: add python3-yaml to runtime dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,6 +15,7 @@ Depends: gir1.2-xapp-1.0 (>= 1.4),
          python3-pil,
          python3-setproctitle,
          python3-tldextract,
+         python3-yaml,
          xapps-common,
          ${misc:Depends},
 Description: Web Application Manager


### PR DESCRIPTION
yaml is imported so obviously we need it as a dependency